### PR TITLE
Supports for specifying HTML elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,11 @@ The default configuration:
 
     // Type: bool
     // Use GET method to upload data? (stringified data will be embedded in URI)
-    enableGet: false
+    enableGet: false,
+
+    // Type: HTML DOM Element
+    // Agent only listens and captures events in `config.scope`
+    scope: window.document
 }
 ```
 

--- a/config.js
+++ b/config.js
@@ -33,12 +33,22 @@ class Config {
         // Time interval for resending the failed trace data
         this.resendInterval = 3000;
 
+        // Type: HTML DOM Element
+        // Capture the events occur in `this.scope`
+        this.scope = window.document;
+
+        // These parameters are required for runing a Mouselog agent
         this._requiredParams = [
             "uploadEndpoint",
         ]
+
+        // These parameters will be ignored when updating config
+        this._ignoredParams = [
+            "scope",
+        ]
     }
 
-    build(config) {
+    build(config, isUpdating = false) {
         try {
             this._requiredParams.forEach(key => {
                 if (!config.hasOwnProperty(key)) {
@@ -49,10 +59,12 @@ class Config {
             Object.keys(config).forEach( key => {
                 // Overwriting Class private members / function method is not allowed
                 if (this[key] && !key.startsWith("_") && typeof(this[key]) != "function") {
-                    this[key] = config[key]
+                    // Do not update some `ignored` parameter
+                    if (isUpdating && !(key in this._ignoredParams)) {
+                        this[key] = config[key]
+                    }
                 }
             })
-
             this.absoluteUrl = this._formatUrl();
         } catch(err) {
             console.log(err);
@@ -62,7 +74,7 @@ class Config {
     }
 
     update(config) {
-        return this.build(config);
+        return this.build(config, true);
     }
 
     _formatUrl() {

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ class Mouselog{
 
     _runCollector() {
         targetEvents.forEach( s => {
-            window.document.addEventListener(s, (evt) => this._mouseHandler(evt));
+            this.config.scope.addEventListener(s, (evt) => this._mouseHandler(evt));
         });
 
         if (this.config.uploadMode === "periodic") {
@@ -133,7 +133,7 @@ class Mouselog{
 
     _stopCollector() {
         targetEvents.forEach( s => {
-            window.document.removeEventListener(s, (evt) => this._mouseHandler(evt));
+            this.config.scope.removeEventListener(s, (evt) => this._mouseHandler(evt));
         });
         clearInterval(this.uploadInterval);
         clearTimeout(this.uploadTimeout);

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ class Mouselog{
         this.mouselogLoadTime = new Date();
         this.uploader = new Uploader();
         this.eventsList = [];
+        this.eventsCount = 0;
         this.uploadInterval; // For "periodic" upload mode
         this.uploadTimeout; // For "mixed" upload mode
     }
@@ -41,8 +42,6 @@ class Mouselog{
             width: document.body.scrollWidth,
             height: document.body.scrollHeight,
             pageLoadTime: pageLoadTime,
-            label: -1,
-            guess: -1,
             events: []
         }
         this.uploadIdx += 1;
@@ -61,8 +60,7 @@ class Mouselog{
             y = evt.changedTouches[0].pageY;
         }
         let tmpEvt = {
-            // TODO: Is `id` be used to order the event by timestamp?
-            id: this.eventsList.length, 
+            id: this.eventsCount, 
             timestamp: getRelativeTimestampInSeconds(),
             type: evt.type,
             x: x,
@@ -70,11 +68,13 @@ class Mouselog{
             button: getButton(evt.button)
         }
 
+
         if (evt.type == "wheel") {
             tmpEvt.deltaX = evt.deltaX;
             tmpEvt.deltaY = evt.deltaY;
         }
         this.eventsList.push(tmpEvt);
+        this.eventsCount += 1;
 
         if ( this.config.uploadMode == "event-triggered" && this.eventsList.length % this.config.frequency == 0 ) {
             this._uploadTrace();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mouselog",
-  "version": "0.0.9-beta2",
+  "version": "0.0.10",
   "description": "The mouse tracking agent for Mouselog.",
   "main": "index.js",
   "homepage": "https://github.com/microsoft/mouselog.js",


### PR DESCRIPTION
1. Mouselog agent is now available for listening and capturing for specified HTML element instead of the full screen. 
2. Fix bugs in uploading data: `label` and `guess` are removed, `id` is fixed.